### PR TITLE
Make builds reproducible

### DIFF
--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -193,7 +193,7 @@ class Vanagon
           default_mode = '0644'
         when "smf"
           # modify version in smf manifest so service gets restarted after package upgrade
-          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{Time.now.to_i}"/' #{service_file}}
+          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{ENV['SOURCE_DATE_EPOCH']}"/' #{service_file}}
           target_service_file = File.join(servicedir, options[:service_type].to_s, "#{service_name}.xml")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -3,6 +3,7 @@ require 'vanagon/logger'
 require 'vanagon/patch'
 require 'ostruct'
 require 'json'
+require 'time'
 
 class Vanagon
   class Component
@@ -192,8 +193,11 @@ class Vanagon
           target_mode = '0644'
           default_mode = '0644'
         when "smf"
+          # A little awkward to do this here since it's defined at the project level, but
+          # this is the only place we need it in here.
+          source_date_epoch = (ENV['SOURCE_DATE_EPOCH'] || Time.now.utc).to_i
           # modify version in smf manifest so service gets restarted after package upgrade
-          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{ENV['SOURCE_DATE_EPOCH']}"/' #{service_file}}
+          @component.install << %{#{@component.platform.sed} -ri 's/(<service.*version=)(".*")/\\1"#{source_date_epoch}"/' #{service_file}}
           target_service_file = File.join(servicedir, options[:service_type].to_s, "#{service_name}.xml")
           target_default_file = File.join(@component.platform.defaultdir, service_name)
           target_mode = '0644'

--- a/lib/vanagon/driver.rb
+++ b/lib/vanagon/driver.rb
@@ -151,7 +151,7 @@ class Vanagon
       @project.generate_packaging_artifacts(workdir) unless @project.no_packaging
       @project.save_manifest_json(@platform, workdir)
       @engine.ship_workdir(workdir)
-      @engine.dispatch("(cd #{@engine.remote_workdir}; #{@platform.make} #{make_target})")
+      @engine.dispatch("(export SOURCE_DATE_EPOCH=#{@project.source_date_epoch}; cd #{@engine.remote_workdir}; #{@platform.make} #{make_target})")
       @engine.retrieve_built_artifact(@project.artifacts_to_fetch, @project.no_packaging)
       @project.publish_yaml_settings(@platform)
 

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -105,7 +105,7 @@ class Vanagon
       # Execute a command on a container via docker exec
       def docker_exec(command, return_output = false)
         command = command.gsub("'", "'\\\\''")
-        Vanagon::Utilities.local_command("#{@docker_cmd} exec -e SOURCE_DATE_EPOCH=#{ENV['SOURCE_DATE_EPOCH']} #{build_host_name}-builder /bin/sh -c '#{command}'",
+        Vanagon::Utilities.local_command("#{@docker_cmd} exec #{build_host_name}-builder /bin/sh -c '#{command}'",
                                          return_command_output: return_output)
       end
 

--- a/lib/vanagon/engine/docker.rb
+++ b/lib/vanagon/engine/docker.rb
@@ -105,7 +105,7 @@ class Vanagon
       # Execute a command on a container via docker exec
       def docker_exec(command, return_output = false)
         command = command.gsub("'", "'\\\\''")
-        Vanagon::Utilities.local_command("#{@docker_cmd} exec #{build_host_name}-builder /bin/sh -c '#{command}'",
+        Vanagon::Utilities.local_command("#{@docker_cmd} exec -e SOURCE_DATE_EPOCH=#{ENV['SOURCE_DATE_EPOCH']} #{build_host_name}-builder /bin/sh -c '#{command}'",
                                          return_command_output: return_output)
       end
 

--- a/lib/vanagon/project.rb
+++ b/lib/vanagon/project.rb
@@ -6,6 +6,7 @@ require 'vanagon/project/dsl'
 require 'vanagon/utilities'
 require 'digest'
 require 'ostruct'
+require 'time'
 
 # Used to parse the vendor field into name and email
 VENDOR_REGEX = /^(.*) <(.*)>$/.freeze
@@ -117,6 +118,9 @@ class Vanagon
     attr_accessor :signing_username
     attr_accessor :signing_command
 
+    # For creating reproducible builds
+    attr_accessor :source_date_epoch
+
     # Loads a given project from the configdir
     #
     # @param name [String] the name of the project
@@ -169,6 +173,7 @@ class Vanagon
       @signing_hostname = ''
       @signing_username = ''
       @signing_command = ''
+      @source_date_epoch = (ENV['SOURCE_DATE_EPOCH'] || Time.now.utc).to_i
     end
 
     # Magic getter to retrieve settings in the project

--- a/resources/deb/changelog.erb
+++ b/resources/deb/changelog.erb
@@ -2,4 +2,4 @@
 
   * Update to version <%= @version %>
 
- -- <%= @vendor %>  <%= Time.now.strftime("%a, %d %b %Y %H:%M:%S %z")%>
+ -- <%= @vendor %>  <%= Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime("%a, %d %b %Y %H:%M:%S %z")%>

--- a/resources/deb/changelog.erb
+++ b/resources/deb/changelog.erb
@@ -2,4 +2,4 @@
 
   * Update to version <%= @version %>
 
- -- <%= @vendor %>  <%= Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime("%a, %d %b %Y %H:%M:%S %z")%>
+ -- <%= @vendor %>  <%= Time.at(@source_date_epoch).utc.strftime("%a, %d %b %Y %H:%M:%S %z")%>

--- a/resources/deb/rules.erb
+++ b/resources/deb/rules.erb
@@ -23,6 +23,8 @@ override_dh_auto_install:
 	cp -Rp <%= file %> debian/tmp/<%= File.dirname(file) %>
 <%- end -%>
 
+override_dh_perl:
+
 override_dh_shlibdeps:
 
 override_dh_usrlocal:

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -396,5 +396,5 @@ fi
 <%- end -%>
 
 %changelog
-* <%= Time.now.strftime("%a %b %d %Y") %> <%= @vendor %> -  <%= @version %>-<%= @release %>
+* <%= Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime("%a %b %d %Y") %> <%= @vendor %> -  <%= @version %>-<%= @release %>
 - Build for <%= @version %>-<%= @release %>

--- a/resources/rpm/project.spec.erb
+++ b/resources/rpm/project.spec.erb
@@ -396,5 +396,5 @@ fi
 <%- end -%>
 
 %changelog
-* <%= Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime("%a %b %d %Y") %> <%= @vendor %> -  <%= @version %>-<%= @release %>
+* <%= Time.at(@source_date_epoch).utc.strftime("%a %b %d %Y") %> <%= @vendor %> -  <%= @version %>-<%= @release %>
 - Build for <%= @version %>-<%= @release %>

--- a/resources/solaris/10/pkginfo.erb
+++ b/resources/solaris/10/pkginfo.erb
@@ -5,7 +5,7 @@ ARCH=<%= @noarch ? 'all' : @platform.architecture %>
 CLASSES=none
 CATEGORY=application
 VENDOR=<%= @vendor %>
-PSTAMP=<%= Time.at(@source_date_epcoh).utc.strftime('%Y-%m-%d.%H%M%S') %>
+PSTAMP=<%= Time.at(@source_date_epoch).utc.strftime('%Y-%m-%d.%H%M%S') %>
 EMAIL=<%= vendor_email_only %>
 ISTATES=S s 1 2 3
 RSTATES=S s 1 2 3

--- a/resources/solaris/10/pkginfo.erb
+++ b/resources/solaris/10/pkginfo.erb
@@ -5,7 +5,7 @@ ARCH=<%= @noarch ? 'all' : @platform.architecture %>
 CLASSES=none
 CATEGORY=application
 VENDOR=<%= @vendor %>
-PSTAMP=<%= Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime('%Y-%m-%d.%H%M%S') %>
+PSTAMP=<%= Time.at(@source_date_epcoh).utc.strftime('%Y-%m-%d.%H%M%S') %>
 EMAIL=<%= vendor_email_only %>
 ISTATES=S s 1 2 3
 RSTATES=S s 1 2 3

--- a/resources/solaris/10/pkginfo.erb
+++ b/resources/solaris/10/pkginfo.erb
@@ -5,7 +5,7 @@ ARCH=<%= @noarch ? 'all' : @platform.architecture %>
 CLASSES=none
 CATEGORY=application
 VENDOR=<%= @vendor %>
-PSTAMP=<%= Time.now.strftime('%Y-%m-%d.%H%M%S') %>
+PSTAMP=<%= Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime('%Y-%m-%d.%H%M%S') %>
 EMAIL=<%= vendor_email_only %>
 ISTATES=S s 1 2 3
 RSTATES=S s 1 2 3


### PR DESCRIPTION
Pass the SOURCE_DATE_EPOCH down to the docker containers to allow reproducible builds.

When generating the changelog entry, also rely on this environment variable.

The caller is expected to provide a value for this variable.
