### PR TITLE
Fix reproducibitily issue with user-defined abbrev length

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -194,7 +194,7 @@ class Vanagon
       # and reachable from the current commit in that repository.
       #
       def version_from_git
-        git_version = Git.open(File.expand_path("..", @configdir)).describe('HEAD', tags: true)
+        git_version = Git.open(File.expand_path("..", @configdir)).describe('HEAD', tags: true, abbrev: 9)
         version(git_version.split('-').reject(&:empty?).join('.'))
       rescue Git::GitExecuteError
         VanagonLogger.error "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"


### PR DESCRIPTION
Users may tune the length of commit IDs abbreviation with something
like:

```
git config --global core.abbrev 12
```

This is reflected in the version / filename of the packages when not
building a tag.

By default, git use an abbreviation length that depends of the number
of objects in the repo.  For the OpenVoxProject/openvox-agent project,
that is currently 9, so hardcode this value so that it does not depend
of users local configuration.

Fixes #3
