### PR TITLE
Changes for MacOS OpenVox builds

### DIFF
--- a/lib/vanagon/platform/defaults/osx-15-arm64.rb
+++ b/lib/vanagon/platform/defaults/osx-15-arm64.rb
@@ -8,17 +8,5 @@ platform 'osx-15-arm64' do |plat|
     plat.provision_with 'export HOMEBREW_VERBOSE=true'
     plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
 
-    plat.provision_with 'sudo dscl . -create /Users/test'
-    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-    plat.provision_with 'sudo dscl . -passwd /Users/test password'
-    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-    plat.provision_with 'mkdir -p /etc/homebrew'
-    plat.provision_with 'cd /etc/homebrew'
-    plat.provision_with 'createhomedir -c -u test'
-    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
     plat.vmpooler_template 'macos-15-arm64'
   end

--- a/lib/vanagon/platform/defaults/osx-15-x86_64.rb
+++ b/lib/vanagon/platform/defaults/osx-15-x86_64.rb
@@ -7,17 +7,5 @@ platform "osx-15-x86_64" do |plat|
   plat.provision_with "export HOMEBREW_VERBOSE=true"
   plat.provision_with "export HOMEBREW_NO_ANALYTICS=1"
 
-  plat.provision_with "sudo dscl . -create /Users/test"
-  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
-  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
-  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
-  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
-  plat.provision_with "sudo dscl . -passwd /Users/test password"
-  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
-  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
-  plat.provision_with "mkdir -p /etc/homebrew"
-  plat.provision_with "cd /etc/homebrew"
-  plat.provision_with "createhomedir -c -u test"
-  plat.provision_with %Q(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
   plat.vmpooler_template "macos-15-x86_64"
 end

--- a/lib/vanagon/platform/osx.rb
+++ b/lib/vanagon/platform/osx.rb
@@ -8,9 +8,7 @@ class Vanagon
       # @return [String] a command to install all of the build dependencies
       def install_build_dependencies(list_build_dependencies)
         <<-HERE.undent
-          mkdir -p /etc/homebrew
-          cd /etc/homebrew
-          su test -c '#{@brew} install #{list_build_dependencies.join(' ')}'
+          #{@brew} install #{list_build_dependencies.join(' ')}
         HERE
       end
 

--- a/resources/Makefile.erb
+++ b/resources/Makefile.erb
@@ -5,7 +5,7 @@ export <%= var %>
 <%- end -%>
 
 tempdir := $(shell <%= @platform.mktemp %> 2>/dev/null)
-workdir := $(PWD)
+workdir := $(shell pwd)
 
 all: file-list-before-build <%= package_name %>
 


### PR DESCRIPTION
At the moment, this relies on a VM set up with homebrew already installed, and does not isolate things to a 'test' user, so you should consider the VM you build on disposable. I could not get the test user commands to work correctly (namely, the part trying to make sudo passwordless) with Sequoia. Will make this better once we get builds working.