### PR TITLE
specify required ruby versions in different format

### DIFF
--- a/vanagon.gemspec
+++ b/vanagon.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.authors  = ['Puppet By Perforce']
   gem.email    = 'release@puppet.com'
   gem.homepage = 'http://github.com/puppetlabs/vanagon'
-  gem.required_ruby_version = '>=2.7', '<4'
+  gem.required_ruby_version = ['>= 2.7', '< 4']
 
   gem.add_dependency('docopt')
   # Handle git repos responsibly


### PR DESCRIPTION
This is a followup for https://github.com/OpenVoxProject/vanagon/actions/runs/14996671825/job/42132507908

dependabot fails with this format:

```
s.required_ruby_version = '>= 2.7', '< 4'
```

full error:

```
updater | /home/dependabot/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:83:in `eval': (eval at /home/dependabot/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:83):1: syntax error, unexpected ',', expecting end-of-input (SyntaxError)
155
'>=2.7', '<4'
156
       ^
```

Please add all notable changes to the "Unreleased" section of the CHANGELOG.