### PR TITLE
Remove weird warning

### DIFF
--- a/lib/vanagon/component/source.rb
+++ b/lib/vanagon/component/source.rb
@@ -69,10 +69,6 @@ class Vanagon
           # URLs that incorrectly respond to git queries
           timeout = 5
           if Vanagon::Component::Source::Git.valid_remote?(uri, timeout)
-            if uri =~ /^http/
-              VanagonLogger.warn "Using http(s) URIs for github is deprecated. " \
-                                 "Use `git:` URI scheme instead."
-            end
             return :git
           end
 


### PR DESCRIPTION
GitHub deprecated and then removed the unencryted git:// protocol
support to access repositories [1].  Using https:// uri for cloning a
public repository without an account like is done by vanagon is the
preferred way today, so we should not warn about it.

1: https://github.blog/security/application-security/improving-git-protocol-security-github/
