### PR TITLE
Fixed: DEPRECATION WARNING: Git::GitExecuteError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](https://keepachangelog.com).
 - Bump minimum ruby requirement to 2.7
 - Fix preserve param default behaving like `always` but should be `on-failure`
 - Fix invalid Debian changelogs (#4)
+- Fix Git::GitExecuteError deprecation
 
 ## [0.53.0] - 2024-09-13
 ### Added

--- a/lib/vanagon/component/source/git.rb
+++ b/lib/vanagon/component/source/git.rb
@@ -116,7 +116,7 @@ class Vanagon
           begin
             @clone ||= ::Git.open(File.join(workdir, dirname))
             @clone.fetch
-          rescue ::Git::GitExecuteError, ArgumentError
+          rescue ::Git::Error, ArgumentError
             clone!
           end
           checkout!
@@ -185,7 +185,7 @@ class Vanagon
         def clone!
           VanagonLogger.info "Cloning Git repo '#{log_url}'"
           VanagonLogger.info "Successfully cloned '#{dirname}'" if clone
-        rescue ::Git::GitExecuteError
+        rescue ::Git::Error
           raise Vanagon::InvalidRepo, "Unable to clone from '#{log_url}'"
         end
         private :clone!
@@ -195,7 +195,7 @@ class Vanagon
         def checkout!
           VanagonLogger.info "Checking out '#{ref}' from Git repo '#{dirname}'"
           clone.checkout(ref)
-        rescue ::Git::GitExecuteError
+        rescue ::Git::Error
           raise Vanagon::CheckoutFailed, "unable to checkout #{ref} from '#{log_url}'"
         end
         private :checkout!
@@ -206,7 +206,7 @@ class Vanagon
         # @return [String] The version of the directory according to git describe
         def describe
           clone.describe(ref, tags: true)
-        rescue ::Git::GitExecuteError
+        rescue ::Git::Error
           VanagonLogger.info "Directory '#{dirname}' cannot be versioned by Git. Maybe it hasn't been tagged yet?"
         end
         private :describe

--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -184,7 +184,7 @@ class Vanagon
         repo_object = Git.open(File.expand_path("..", @configdir))
         last_tag = repo_object.describe('HEAD', { :abbrev => 0 })
         release(repo_object.rev_list("#{last_tag}..HEAD", { :count => true }))
-      rescue Git::GitExecuteError
+      rescue Git::Error
         VanagonLogger.error "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
       end
 
@@ -195,7 +195,7 @@ class Vanagon
       def version_from_git
         git_version = Git.open(File.expand_path("..", @configdir)).describe('HEAD', tags: true, abbrev: 9)
         version(git_version.split('-').reject(&:empty?).join('.'))
-      rescue Git::GitExecuteError
+      rescue Git::Error
         VanagonLogger.error "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
       end
 
@@ -212,7 +212,7 @@ class Vanagon
         else
           fail "Can't find a version in your branch, make sure it matches <number>.<number>, like maint/1.7.0/fixing-some-bugs"
         end
-      rescue Git::GitExecuteError => e
+      rescue Git::Error => e
         fail "Something went wrong trying to find your git branch.\n#{e}"
       end
 


### PR DESCRIPTION
Updating code base to use new Git::Error as per the warning Git::GitExecuteError will soon be deprecated.