### PR TITLE
Delete legacy PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-Please add all notable changes to the "Unreleased" section of the CHANGELOG.


### PR DESCRIPTION
The previous content just doesn't make sense for our workflow.