### PR TITLE
Release job: Cleanup github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,44 +6,60 @@ on:
     tags:
       - '*'
 
+permissions: {}
+
 jobs:
-  release:
-    name: Release gem
-    runs-on: ubuntu-24.04
-    # Optional but recommended to use a specific environment
-    environment: release
+  build-release:
     # Prevent releases from forked repositories
     if: github.repository_owner == 'OpenVoxProject'
-
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-
+    name: Build the gem
+    runs-on: ubuntu-24.04
     steps:
-      # we cannot publish to rubygems.org until we rename the project
-      # https://rubygems.org/gems/vanagon owned by Perforce
-      # - uses: voxpupuli/ruby-release@v0
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
-        env:
-          BUNDLE_WITHOUT: ec2-engine:development:test
+          ruby-version: 'ruby'
       - name: Build gem
-        run: gem build --strict --verbose *.gemspec
-      - name: Setup GitHub packages access
-        run: |
-          mkdir -p ~/.gem
-          echo ":github: Bearer ${{ secrets.GITHUB_TOKEN }}" >> ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-      - name: Publish gem to GitHub packages
-        run: gem push --key github --host https://rubygems.pkg.github.com/openvoxproject *.gem
-      - name: Create Release Page
+        shell: bash
+        run: gem build --verbose *.gemspec
+      - name: Upload gem to GitHub cache
+        uses: actions/upload-artifact@v4
+        with:
+          name: gem-artifact
+          path: '*.gem'
+          retention-days: 1
+          compression-level: 0
+
+  create-github-release:
+    needs: build-release
+    name: Create GitHub release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # clone repo and create release
+    steps:
+      - name: Download gem from GitHub cache
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Create Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --generate-notes
+        run: gh release create --repo ${{ github.repository }} ${{ github.ref_name }} --generate-notes *.gem
+
+  release-to-github:
+    needs: build-release
+    name: Release to GitHub
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write # publish to rubygems.pkg.github.com
+    steps:
+      - name: Download gem from GitHub cache
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Publish gem to GitHub packages
+        run: gem push --host https://rubygems.pkg.github.com/${{ github.repository_owner }} *.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This follows our best practice from
https://github.com/voxpupuli/gem-workflow-test/blob/master/.github/workflows/release.yml (except for the release to rubygems, because that namespace is owned by Perforce).