### PR TITLE
Tweaks for redhatfips for OpenVox

### DIFF
--- a/lib/vanagon/platform/defaults/redhatfips-8-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-8-x86_64.rb
@@ -27,4 +27,8 @@ platform "redhatfips-8-x86_64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-fips-8-x86_64"
+  # NOTE: You must run the build on a FIPS-enabled Linux host in order for this platform to
+  # build correctly with the Docker engine.
+  plat.docker_image "almalinux:8"
+  plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/redhatfips-9-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-9-x86_64.rb
@@ -20,11 +20,15 @@ platform "redhatfips-9-x86_64" do |plat|
     rsync
     swig
     systemtap-sdt-devel
-    yum-utils
     zlib-devel
   )
 
+  plat.provision_with "dnf install -y yum-utils && dnf config-manager --set-enabled crb"
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-fips-9-x86_64"
+  # NOTE: You must run the build on a FIPS-enabled Linux host in order for this platform to
+  # build correctly with the Docker engine.
+  plat.docker_image "almalinux:9"
+  plat.docker_arch "linux/amd64"
 end


### PR DESCRIPTION
These changes are needed in order to build FIPS agents for OpenVox. It must be run on a FIPS-enabled host, but when you do, the container will be in FIPS mode too, so we just need to use the same image as non-FIPS.