### PR TITLE
Expand local url path

### DIFF
--- a/lib/vanagon/component/source/local.rb
+++ b/lib/vanagon/component/source/local.rb
@@ -32,7 +32,7 @@ class Vanagon
           # once upon a time we allowed specifying files with no strong
           # specifications for where they should be located.
           def mangle(path)
-            path.gsub(%r{^file://}, '')
+            File.absolute_path(path.gsub(%r{^file://}, ''))
           end
 
           def archive_extensions


### PR DESCRIPTION
This allows us to use relative paths in file:// URLs, which we will be doing in the openvox repo when we move vanagon packaging into the repo.