### PR TITLE
Cleanup Rakefile dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-require 'bundler/setup'
-require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'yard'


### PR DESCRIPTION
previously we loaded the bundler tasks, they provide the following tasks:

```
rake build                    # Build vanagon-1.0.0.gem into the pkg directory
rake build:checksum           # Generate SHA512 checksum of vanagon-1.0.0.gem into the checksums directory
rake clean                    # Remove any temporary products
rake clobber                  # Remove any generated files
rake install                  # Build and install vanagon-1.0.0.gem into system gems
rake install:local            # Build and install vanagon-1.0.0.gem into system gems without network access
rake release[remote]          # Create tag v1.0.0 and build and push vanagon-1.0.0.gem to rubygems.org
```

But we don't use them, so we can disable them.