### PR TITLE
Remove comment about FIPS builds

### DIFF
--- a/lib/vanagon/platform/defaults/redhatfips-8-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-8-x86_64.rb
@@ -27,8 +27,6 @@ platform "redhatfips-8-x86_64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-fips-8-x86_64"
-  # NOTE: You must run the build on a FIPS-enabled Linux host in order for this platform to
-  # build correctly with the Docker engine.
   plat.docker_image "almalinux:8"
   plat.docker_arch "linux/amd64"
 end

--- a/lib/vanagon/platform/defaults/redhatfips-9-x86_64.rb
+++ b/lib/vanagon/platform/defaults/redhatfips-9-x86_64.rb
@@ -27,8 +27,6 @@ platform "redhatfips-9-x86_64" do |plat|
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
   plat.vmpooler_template "redhat-fips-9-x86_64"
-  # NOTE: You must run the build on a FIPS-enabled Linux host in order for this platform to
-  # build correctly with the Docker engine.
   plat.docker_image "almalinux:9"
   plat.docker_arch "linux/amd64"
 end


### PR DESCRIPTION
After doing some research, I'm fairly confident we should be able to build the redhatfips artifacts on a non-FIPS enabled host. There should be no hidden checks of the fips_enabled file inside the individual components we are building.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
