### PR TITLE
Update github_changelog_generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,5 @@ end
 
 group :release, optional: true do
   gem 'faraday-retry', '~> 2.1', require: false
-  gem 'github_changelog_generator', '~> 1.16.4', require: false
+  gem 'github_changelog_generator', '~> 1.18', require: false
 end


### PR DESCRIPTION
### Update github_changelog_generator to ~> 1.18

Replace fork/outdated version pins with the released 1.18 gem which
includes the duplicate commit processing fix upstream.