### PR TITLE
CI: run rubocop only once

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         ruby-version: '3.4'
         bundler-cache: true
+    - name: Run Rubocop
+      run: bundle exec rake rubocop
     - id: ruby
       uses: voxpupuli/ruby-version@v2
 
@@ -41,7 +43,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: bundle exec rake
+        run: bundle exec rake check
       - name: Build gem
         run: gem build --strict --verbose *.gemspec
 


### PR DESCRIPTION
previously, we called the default rake task, which runs the unit tests and afterwards rubocop. That doesn't make much sense. We usually run rubocop once, before generating the matrix. We can do the same here.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
