### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -56,7 +56,6 @@ end" }
 
   describe '#release_from_git' do
     it 'sets the release based on commits since last tag' do
-      repo = double
       tag = double
       log = double
       diff = double


### PR DESCRIPTION
To fix this without changing functionality, remove the redundant `repo = double` assignment in `spec/lib/vanagon/project/dsl_spec.rb` inside the `describe '#release_from_git'` test case. Keep the later `repo = double("repo")` assignment, since that is the object used in all expectations and stubs.

Specifically:
- In the `it 'sets the release based on commits since last tag' do` block, delete the early `repo = double` line.
- No method changes, import changes, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._