### PR TITLE
Pass full options hashes from component.add_source

### DIFF
--- a/lib/vanagon/component.rb
+++ b/lib/vanagon/component.rb
@@ -360,12 +360,14 @@ class Vanagon
     # @param workdir [String] working directory to put the source into
     def get_sources(workdir) # rubocop:disable Metrics/AbcSize
       sources.each do |source|
-        src = Vanagon::Component::Source.source(
-          source.url, workdir: workdir, ref: source.ref, sum: source.sum
-        )
+        options = source.to_h # Copy OpenStruct to Hash.
+        url     = options.delete(:url)
+        erb     = options.delete(:erb)
+        options[:workdir] = workdir
+        src = Vanagon::Component::Source.source(url, **options)
         src.fetch
         src.verify
-        if source.erb
+        if erb
           erb_file(src.file, File.join(File.dirname(src.file), File.basename(src.file, ".erb")), true)
         end
         # set src.file to only be populated with the basename instead of entire file path

--- a/lib/vanagon/component/dsl.rb
+++ b/lib/vanagon/component/dsl.rb
@@ -406,9 +406,9 @@ class Vanagon
       # This will add a source to the project and put it in the workdir alongside the other sources
       #
       # @param uri [String] uri of the source
-      # @param [Hash] options optional keyword arguments used to instatiate a new source
-      #   @option opts [String] :sum
-      #   @option opts [String] :ref
+      # @param [Hash] options optional keyword arguments used to instatiate a new source.
+      #               See {Vanagon::Component::Source::Local}, {Vanagon::Component::Source::Git},
+      #               and {Vanagon::Component::Source::Http} for details.
       #   @option opts [Bool] :erb set to 'true' to specify that the source file should be
       #     translated by erb
       def add_source(uri, options = {})

--- a/spec/lib/vanagon/component_spec.rb
+++ b/spec/lib/vanagon/component_spec.rb
@@ -217,6 +217,28 @@ describe "Vanagon::Component" do
       expect(subject).to_not receive(:erb_file)
       subject.get_sources(@workdir)
     end
+
+    it "Allows checksum types to be specified" do
+      plat = Vanagon::Platform::DSL.new('el-10-x86_64')
+      plat.instance_eval("platform 'el-10-x86_64' do |plat| end")
+      @platform = plat._platform
+
+      comp = Vanagon::Component::DSL.new('build-dir-test', {}, @platform)
+      comp.add_source  @fake_file,
+                       # Checksum of spec/fixtures/files/fake_file.txt
+                       sum: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+                       sum_type: 'sha256'
+      subject = comp._component
+
+      # Not the best test as local files don't execute verification logic.
+      # However, properly mocking the download logic of a HTTP source would
+      # require a re-write of the class.
+      expect(Vanagon::Component::Source).to receive(:source)
+        .with(anything, hash_including(sum_type: 'sha256'))
+        .and_call_original
+
+      subject.get_sources(@workdir)
+    end
   end
 
   describe "#get_patches" do


### PR DESCRIPTION
Prior to this commit, the `add_source` method of the would accept any number of keyword arguments, but silently ignored any that were not `ref` or `sum`. The Git and Http sources accept many options, critically `sum_type` which allows checksums other than MD5 to be used.

This commit updates the logic in `lib/vanagon/component.rb` to ensure all options are passed to the source constructor.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
