### PR TITLE
Write downloaded content in binary mode

### DIFF
--- a/lib/vanagon/component/source/http.rb
+++ b/lib/vanagon/component/source/http.rb
@@ -138,7 +138,7 @@ class Vanagon
                 location = URI.parse(response.header['location'])
                 download(uri + location, target_file)
               when Net::HTTPSuccess
-                File.open(File.join(@workdir, target_file), 'w') do |io|
+                File.open(File.join(@workdir, target_file), 'wb') do |io|
                   response.read_body { |chunk| io.write(chunk) }
                 end
               else


### PR DESCRIPTION
This commit updates the logic for downloading component packages via HTTP to write file content out in binary mode. When running under a native Windows Ruby, opening files in `w` mode causes any `\n` sequences in the datastream to be expanded to `\r\n`. This corrupts the downloads and causes checksumming to fail.

Opening files in `wb` mode skips all of this silliness and just writes the bytes.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
