### PR TITLE
Add windows-msys2-x64 platform definition

### DIFF
--- a/lib/vanagon/platform/defaults/windows-msys2-x64.rb
+++ b/lib/vanagon/platform/defaults/windows-msys2-x64.rb
@@ -1,6 +1,4 @@
 platform 'windows-msys2-x64' do |plat|
-  plat.vmpooler_template 'win-2022-x86_64'
-
   plat.servicetype 'windows'
 
   # MSYS2 must be pre-installed at C:/msys64 on the build image.

--- a/lib/vanagon/platform/defaults/windows-msys2-x64.rb
+++ b/lib/vanagon/platform/defaults/windows-msys2-x64.rb
@@ -12,8 +12,19 @@ platform 'windows-msys2-x64' do |plat|
     mingw-w64-ucrt-x86_64-gcc-libs
   ]
 
-  plat.provision_with("C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed #{packages.join(' ')}")
-  plat.install_build_dependencies_with 'C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed'
+  # Story time:
+  #
+  # Windows can end up with multiple MSYS2 installations. This is common
+  # on GitHub actions where the runner image comes with `C:/msys64/`
+  # pre-installed, but inactive, and the `msys/setup-msys2` creates a new
+  # installation under `D:/a/_temp/msys64/`.
+  #
+  # Thus: assume Vanagon is running in a MSYS2 shell which mounts the chosen
+  # MSYS2 installation and sets PATH appropriately. "UNIX" paths in this shell,
+  # like `/usr/bin/` should work fine, but fully-qualified Windows paths like
+  # `C:/msys64/usr/bin/` might point to the "wrong" MSYS2 installation.
+  plat.provision_with("/usr/bin/pacman -S --noconfirm --needed #{packages.join(' ')}")
+  plat.install_build_dependencies_with '/usr/bin/pacman -S --noconfirm --needed'
 
   plat.make '/usr/bin/make'
   plat.patch 'TMP=/var/tmp /usr/bin/patch.exe --binary'

--- a/lib/vanagon/platform/defaults/windows-msys2-x64.rb
+++ b/lib/vanagon/platform/defaults/windows-msys2-x64.rb
@@ -1,21 +1,15 @@
 platform 'windows-msys2-x64' do |plat|
   plat.servicetype 'windows'
 
-  # MSYS2 must be pre-installed at C:/msys64 on the build image.
-  # Install required UCRT64 toolchain and library packages via pacman.
-  packages = [
-    'autoconf',
-    'git',
-    'make',
-    'mingw-w64-ucrt-x86_64-gcc',
-    'mingw-w64-ucrt-x86_64-gdbm',
-    'mingw-w64-ucrt-x86_64-libffi',
-    'mingw-w64-ucrt-x86_64-libyaml',
-    'mingw-w64-ucrt-x86_64-readline',
-    'mingw-w64-ucrt-x86_64-ruby',
-    'mingw-w64-ucrt-x86_64-zlib',
-    'mingw-w64-ucrt-x86_64-gcc-libs',
-    'patch',
+  packages = %w[
+    autoconf
+    git
+    make
+    patch
+    mingw-w64-ucrt-x86_64-gcc
+    mingw-w64-ucrt-x86_64-gdbm
+    mingw-w64-ucrt-x86_64-zlib
+    mingw-w64-ucrt-x86_64-gcc-libs
   ]
 
   plat.provision_with("C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed #{packages.join(' ')}")

--- a/lib/vanagon/platform/defaults/windows-msys2-x64.rb
+++ b/lib/vanagon/platform/defaults/windows-msys2-x64.rb
@@ -1,0 +1,39 @@
+platform 'windows-msys2-x64' do |plat|
+  plat.vmpooler_template 'win-2022-x86_64'
+
+  plat.servicetype 'windows'
+
+  # MSYS2 must be pre-installed at C:/msys64 on the build image.
+  # Install required UCRT64 toolchain and library packages via pacman.
+  packages = [
+    'autoconf',
+    'git',
+    'make',
+    'mingw-w64-ucrt-x86_64-gcc',
+    'mingw-w64-ucrt-x86_64-gdbm',
+    'mingw-w64-ucrt-x86_64-libffi',
+    'mingw-w64-ucrt-x86_64-libyaml',
+    'mingw-w64-ucrt-x86_64-readline',
+    'mingw-w64-ucrt-x86_64-ruby',
+    'mingw-w64-ucrt-x86_64-zlib',
+    'mingw-w64-ucrt-x86_64-gcc-libs',
+    'patch',
+  ]
+
+  plat.provision_with("C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed #{packages.join(' ')}")
+  plat.install_build_dependencies_with 'C:/msys64/usr/bin/pacman.exe -S --noconfirm --needed'
+
+  plat.make '/usr/bin/make'
+  plat.patch 'TMP=/var/tmp /usr/bin/patch.exe --binary'
+
+  plat.platform_triple 'x86_64-w64-mingw32'
+
+  # In the MSYS2 UCRT64 environment, gcc is the native UCRT64 compiler.
+  # Do not use the full x86_64-w64-mingw32- prefix here; that is only needed
+  # when cross-compiling from a Cygwin host.
+  plat.environment 'CC', 'gcc'
+  plat.environment 'CXX', 'g++'
+
+  plat.package_type 'archive'
+  plat.output_dir 'windows'
+end

--- a/lib/vanagon/platform/defaults/windows-msys2-x64.rb
+++ b/lib/vanagon/platform/defaults/windows-msys2-x64.rb
@@ -36,6 +36,6 @@ platform 'windows-msys2-x64' do |plat|
   # Otherwise, autoconf gets confused.
   plat.environment 'CC', 'x86_64-w64-mingw32-gcc'
 
-  plat.package_type 'archive'
+  plat.package_type 'msi'
   plat.output_dir 'windows'
 end

--- a/lib/vanagon/platform/defaults/windows-msys2-x64.rb
+++ b/lib/vanagon/platform/defaults/windows-msys2-x64.rb
@@ -31,11 +31,10 @@ platform 'windows-msys2-x64' do |plat|
 
   plat.platform_triple 'x86_64-w64-mingw32'
 
-  # In the MSYS2 UCRT64 environment, gcc is the native UCRT64 compiler.
-  # Do not use the full x86_64-w64-mingw32- prefix here; that is only needed
-  # when cross-compiling from a Cygwin host.
-  plat.environment 'CC', 'gcc'
-  plat.environment 'CXX', 'g++'
+  # Putting these here as a reminder where we use them elsewhere. DO NOT
+  # use the full path, just the name of the executable without the extension.
+  # Otherwise, autoconf gets confused.
+  plat.environment 'CC', 'x86_64-w64-mingw32-gcc'
 
   plat.package_type 'archive'
   plat.output_dir 'windows'


### PR DESCRIPTION
### Short description

This changeset adds a `windows-msys2-x64` platform definition that is
mostly a copy of the existing Cygwin-based `windows-all-x64`.
Vanagon builds that use this platform should be run inside a MSYS2
bash shell and use the `MSYS/ruby` package to run Vanagon. This provides
a Cygwin-ish, POSIX-ish, execution environment that Vanagon expects
and that somewhat mirrors the Cygwin environment used by the existing
`windows-all-x64` platform. Do not use the `UCRT64/ruby` package to
run Vanagon as this is "Windows native" instead of POSIX and will try
to use Windows paths, Windows line endings, and importantly will also
try to run Vanagon shell commands through `cmd.exe` instead of
`bash.exe`.

The platform is configured to install the `UCRT64/gcc` package
and components are set to build Windows native executables linked
against the `ucrt` C runtime required by Ruby 4.0.

This changeset is based on work by @sebastianrakel:

  https://github.com/OpenVoxProject/puppet-runtime/commit/622973629bdf6138b942745c65a8ad313fede508


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
