### PR TITLE
Handle pre-release versions

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -194,7 +194,16 @@ class Vanagon
       #
       def version_from_git
         git_version = Git.open(File.expand_path("..", @configdir)).describe('HEAD', tags: true, abbrev: 9)
-        version(git_version.split('-').reject(&:empty?).join('.'))
+        case git_version
+        # Matches semver.org spec for a pre-release, with a well-known alpha,
+        # beta, or RC identifier. Substitute "-" for "~" so that dpkg and
+        # rpm treat this as a pre-release and will upgrade packages to the
+        # final version.
+        when /\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+/
+          version(git_version.sub('-', '~'))
+        else
+          version(git_version.split('-').reject(&:empty?).join('.'))
+        end
       rescue Git::Error
         VanagonLogger.error "Directory '#{File.expand_path('..', @configdir)}' cannot be versioned by git. Maybe it hasn't been tagged yet?"
       end


### PR DESCRIPTION
### Short description

This commit updates the logic that generates package versions from Git tags. If the tag matches a semver.org pre-release with "alpha", "beta" or "rc" as the pre-release identifier, then the "-" in the version string is substituted for "~". That is, a tag like `9.0.0-beta1` becomes the following package version: `9.0.0~beta1`

This is done because the `dpkg` and `rpm` package managers treat `~` specially and sort any version strings containing it before all other strings. This changes allows a `9.0.0~alpha1` package to upgrade to `9.0.0~beta1`, and then to `9.0.0~rc0`, and finally to `9.0.0`.

See: https://semver.org
See: https://manpages.debian.org/bookworm/dpkg-dev/deb-version.7.en.html#Sorting_algorithm
See: https://rpm.org/docs/6.0.x/man/rpm-version.7#Comparing


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
