### PR TITLE
Anchor pre-release regex on end of string

### DIFF
--- a/lib/vanagon/project/dsl.rb
+++ b/lib/vanagon/project/dsl.rb
@@ -199,7 +199,7 @@ class Vanagon
         # beta, or RC identifier. Substitute "-" for "~" so that dpkg and
         # rpm treat this as a pre-release and will upgrade packages to the
         # final version.
-        when /\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+/
+        when /\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+\z/
           version(git_version.sub('-', '~'))
         else
           version(git_version.split('-').reject(&:empty?).join('.'))

--- a/spec/lib/vanagon/project/dsl_spec.rb
+++ b/spec/lib/vanagon/project/dsl_spec.rb
@@ -13,44 +13,58 @@ end" }
   end
 
   describe '#version_from_git' do
-    it 'sets the version based on the git describe' do
-      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
-      proj.instance_eval(project_block)
+    let(:project) { Vanagon::Project::DSL.new('test-fixture', configdir, platform) }
+    let(:repo) { double('repo') }
+    subject { project._project }
 
-      # Lying is bad. You shouldn't lie. But sometimes when you're
-      # working with gross abstractions piled into the shape of
-      # an indescribable cyclopean obelisk, you might have to lie
-      # a little bit. Instead of trying to mock an entire Git instance,
-      # we'll just instantiate a Double and allow it to receive calls
-      # to .describe like it was a valid Git instance.
-      repo = double("repo")
+    before(:each) do
+      project.instance_eval(project_block)
+
       expect(::Git)
         .to receive(:open)
         .and_return(repo)
+    end
 
+    it 'sets the version based on the git describe' do
       allow(repo)
         .to receive(:describe)
         .and_return('1.2.3-1234')
 
-      proj.version_from_git
-      expect(proj._project.version).to eq('1.2.3.1234')
+      project.version_from_git
+
+      expect(subject.version).to eq('1.2.3.1234')
     end
+
     it 'sets the version based on the git describe with multiple dashes' do
-      proj = Vanagon::Project::DSL.new('test-fixture', configdir, platform)
-      proj.instance_eval(project_block)
-
-      # See previous description of "indescribable cyclopean obelisk"
-      repo = double("repo")
-      expect(::Git)
-        .to receive(:open)
-        .and_return(repo)
-
       expect(repo)
         .to receive(:describe)
         .and_return('1.2.3---1234')
 
-      proj.version_from_git
-      expect(proj._project.version).to eq('1.2.3.1234')
+      project.version_from_git
+
+      expect(subject.version).to eq('1.2.3.1234')
+    end
+
+    %w[alpha1 beta2 rc0].each do |pre_release|
+      it "munges tagged #{pre_release} pre-release versions to include a tilde" do
+        expect(repo)
+          .to receive(:describe)
+          .and_return("1.2.3-#{pre_release}")
+
+        project.version_from_git
+
+        expect(subject.version).to eq("1.2.3~#{pre_release}")
+      end
+    end
+
+    it "does not munge a tilde into un-tagged pre-release versions" do
+      expect(repo)
+        .to receive(:describe)
+        .and_return("1.2.3-beta10-42-gabcdef123")
+
+      project.version_from_git
+
+      expect(subject.version).to eq("1.2.3.beta10.42.gabcdef123")
     end
   end
 


### PR DESCRIPTION
### Short description

This commit makes a small change to the regex for determining when to build a pre-release to anchor on the end of the string. This means that only full git tags, such as `9.0.0-beta1`, will be matched and not git describe output for releases between tags, like: `9.0.0-beta1-9-g347642bbe`

Proper test coverage for version munging is also added.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
